### PR TITLE
Fix build with gfortran >= 10.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ all: nvtx_example
 
 FC=pgf90
 #FC=gfortran
+#FC=ifort
+#FC=ifx
 
 nvtx_example:: main.f90 nvtx.f90
 	$(FC) -o nvtx_example nvtx.f90 main.f90 -L/usr/local/cuda/lib64 -lnvToolsExt
 
 clean:
-	rm  nvtx_example main.o nvtx.o   nvtx.mod
+	rm -f nvtx_example main.o nvtx.o nvtx.mod

--- a/nvtx.f90
+++ b/nvtx.f90
@@ -3,7 +3,15 @@ module nvtx
 use iso_c_binding
 implicit none
 
-integer,private :: col(7) = [ Z'0000ff00', Z'000000ff', Z'00ffff00', Z'00ff00ff', Z'0000ffff', Z'00ff0000', Z'00ffffff']
+integer(kind=C_INT32_T), private :: col(7) = [ &
+  & int(Z'0000ff00',kind=C_INT32_T), &
+  & int(Z'000000ff',kind=C_INT32_T), &
+  & int(Z'00ffff00',kind=C_INT32_T), &
+  & int(Z'00ff00ff',kind=C_INT32_T), &
+  & int(Z'0000ffff',kind=C_INT32_T), &
+  & int(Z'00ff0000',kind=C_INT32_T), &
+  & int(Z'00ffffff',kind=C_INT32_T) ]
+
 character,private,target :: tempName(256)
 
 type, bind(C):: nvtxEventAttributes


### PR DESCRIPTION
Build error was:
  Error: BOZ literal constant at (1) cannot appear in an array constructor
  
  